### PR TITLE
Mongodb Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ FROM node:16.19-bullseye-slim
 # Positively impacts the performance of several libraries.
 ENV NODE_ENV production
 
+# Install libcurl4 in production image - which is not installed by default on slim images.
+RUN apt-get update && apt-get install -y --no-install-recommends libcurl4
+
 # Copy dumb-init process supervisor
 COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,6 @@ WORKDIR /usr/src/app
 COPY --chown=node:node --from=build /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --chown=node:node . /usr/src/app
 
+EXPOSE 3000
+
 CMD ["dumb-init", "node", "server.js"]


### PR DESCRIPTION
### Changes
- Added port 3000 as default
- Included libcurl4 in production debian slim image.